### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/phyn/sensor.py
+++ b/custom_components/phyn/sensor.py
@@ -76,7 +76,7 @@ class PhynCurrentFlowRateSensor(PhynEntity, SensorEntity):
 
     _attr_device_class = SensorDeviceClass.WATER
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
-    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
 
     def __init__(self, device):
         """Initialize the flow rate sensor."""


### PR DESCRIPTION
Changed Sensor state class from "MEASUREMENT" to "TOTAL" for current water flow rate due to following Home Assistant error message:

"Entity sensor.phyn_pp1_average_water_flow_rate (<class 'custom_components.phyn.sensor.PhynCurrentFlowRateSensor'>) is using state class 'measurement' which is impossible considering device class ('water') it is using; expected None or one of 'total', 'total_increasing'; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author."