### PR TITLE
Fix integration to support setups with Phyn Smart Water Sensors added

### DIFF
--- a/custom_components/phyn/sensor.py
+++ b/custom_components/phyn/sensor.py
@@ -39,14 +39,15 @@ async def async_setup_entry(
     ]["devices"]
     entities = []
     for device in devices:
-        entities.extend(
-            [
-                PhynDailyUsageSensor(device),
-                PhynCurrentFlowRateSensor(device),
-                PhynTemperatureSensor(NAME_WATER_TEMPERATURE, device),
-                PhynPressureSensor(device),
-            ]
-        )
+        if device.model == 'PP1' or device.model == 'PP2':
+            entities.extend(
+                [
+                    PhynDailyUsageSensor(device),
+                    PhynCurrentFlowRateSensor(device),
+                    PhynTemperatureSensor(NAME_WATER_TEMPERATURE, device),
+                    PhynPressureSensor(device),
+                ]
+            )
     async_add_entities(entities)
 
 

--- a/custom_components/phyn/switch.py
+++ b/custom_components/phyn/switch.py
@@ -27,7 +27,8 @@ async def async_setup_entry(
     ]["devices"]
     entities = []
     for device in devices:
-        entities.append(PhynSwitch(device))
+        if device.model == 'PP1' or device.model == 'PP2':
+            entities.append(PhynSwitch(device))
     async_add_entities(entities)
 
 


### PR DESCRIPTION
Currently the integration works fine if the Phyn setup only has the Phyn Plus (pp1 or pp2). However, if there are Phyn Smart Water Sensors (pw1) in the Phyn setup, the integration crashes during this integration's setup -- all sorts of errors are generated as HA iterates through adding the pp1/pp2 as well as every pw1 in the system.

This change checks to only add the Phyn Plus (pp1 or pp2) to HA. It paves the way so we can add (different attributes belong to) pw1's to HA in a future PR.