### PR TITLE
Phyn Smart Water Assistant Support

### DIFF
--- a/custom_components/phyn/__init__.py
+++ b/custom_components/phyn/__init__.py
@@ -17,6 +17,7 @@ from .device import PhynDeviceDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+PLATFORMS_PC1 = [Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -44,7 +45,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     tasks = [device.async_refresh() for device in devices]
     await asyncio.gather(*tasks)
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    if any("PP1" in device.get("product_code", "") for home in homes for device in home["devices"]):
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    else:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS_PC1)
 
     return True
 

--- a/custom_components/phyn/device.py
+++ b/custom_components/phyn/device.py
@@ -94,6 +94,26 @@ class PhynDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     def temperature(self) -> float:
         """Return the current temperature in degrees F."""
         return self._device_state["temperature"]["mean"]
+        
+    @property
+    def current_psi1(self) -> float:
+        """Return the current pressure in psi."""
+        return self._device_state["pressure1"]["mean"]
+
+    @property
+    def temperature1(self) -> float:
+        """Return the current temperature in degrees F."""
+        return self._device_state["temperature1"]["mean"]
+        
+    @property
+    def current_psi2(self) -> float:
+        """Return the current pressure in psi."""
+        return self._device_state["pressure2"]["mean"]
+
+    @property
+    def temperature2(self) -> float:
+        """Return the current temperature in degrees F."""
+        return self._device_state["temperature2"]["mean"]
 
     @property
     def consumption_today(self) -> float:

--- a/custom_components/phyn/sensor.py
+++ b/custom_components/phyn/sensor.py
@@ -25,7 +25,11 @@ GAUGE_ICON = "mdi:gauge"
 NAME_DAILY_USAGE = "Daily water usage"
 NAME_FLOW_RATE = "Average water flow rate"
 NAME_WATER_TEMPERATURE = "Average water temperature"
+NAME_HOT_WATER_TEMPERATURE = "Average hot water temperature"
+NAME_COLD_WATER_TEMPERATURE = "Average cold water temperature"
 NAME_WATER_PRESSURE = "Average water pressure"
+NAME_HOT_WATER_PRESSURE = "Average hot water pressure"
+NAME_COLD_WATER_PRESSURE = "Average cold water pressure"
 
 
 async def async_setup_entry(
@@ -39,14 +43,21 @@ async def async_setup_entry(
     ]["devices"]
     entities = []
     for device in devices:
-        entities.extend(
-            [
+        if device.model == 'PC1':
+            entities.extend([
+                PhynDailyUsageSensor(device),
+                PhynTemperature1Sensor(NAME_HOT_WATER_TEMPERATURE, device),
+                PhynPressure1Sensor(NAME_HOT_WATER_PRESSURE, device),
+                PhynTemperature2Sensor(NAME_COLD_WATER_TEMPERATURE, device),
+                PhynPressure2Sensor(NAME_COLD_WATER_PRESSURE, device),
+            ])
+        else:
+            entities.extend([
                 PhynDailyUsageSensor(device),
                 PhynCurrentFlowRateSensor(device),
                 PhynTemperatureSensor(NAME_WATER_TEMPERATURE, device),
                 PhynPressureSensor(device),
-            ]
-        )
+            ])
     async_add_entities(entities)
 
 
@@ -129,3 +140,81 @@ class PhynPressureSensor(PhynEntity, SensorEntity):
         if self._device.current_psi is None:
             return None
         return round(self._device.current_psi, 1)
+        
+class PhynTemperature1Sensor(PhynEntity, SensorEntity):
+    """Monitors the temperature1."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+
+    def __init__(self, name, device):
+        """Initialize the temperature 1 sensor."""
+        super().__init__("temperature1", name, device)
+        self._state: float = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current temperature 1."""
+        if self._device.temperature1 is None:
+            return None
+        return round(self._device.temperature1, 1)
+
+
+class PhynPressure1Sensor(PhynEntity, SensorEntity):
+    """Monitors the water pressure1."""
+
+    _attr_device_class = SensorDeviceClass.PRESSURE
+    _attr_native_unit_of_measurement = UnitOfPressure.PSI
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+
+    def __init__(self, name, device):
+        """Initialize the pressure1 sensor."""
+        super().__init__("water_pressure1", name, device)
+        self._state: float = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current water pressure1."""
+        if self._device.current_psi1 is None:
+            return None
+        return round(self._device.current_psi1, 1)
+        
+class PhynTemperature2Sensor(PhynEntity, SensorEntity):
+    """Monitors the temperature2."""
+
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.FAHRENHEIT
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+
+    def __init__(self, name, device):
+        """Initialize the temperature2 sensor."""
+        super().__init__("temperature2", name, device)
+        self._state: float = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current temperature2."""
+        if self._device.temperature2 is None:
+            return None
+        return round(self._device.temperature2, 1)
+
+
+class PhynPressure2Sensor(PhynEntity, SensorEntity):
+    """Monitors the water pressure2."""
+
+    _attr_device_class = SensorDeviceClass.PRESSURE
+    _attr_native_unit_of_measurement = UnitOfPressure.PSI
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+
+    def __init__(self, name, device):
+        """Initialize the pressure2 sensor."""
+        super().__init__("water_pressure2", name, device)
+        self._state: float = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current water pressure2."""
+        if self._device.current_psi2 is None:
+            return None
+        return round(self._device.current_psi2, 1)


### PR DESCRIPTION
This adds support for Classic Phyn Smart Water Assistant with Cold and Hot Water Lines. It will not create a Switch when just PC1 is available. It supports Hot and Cold Water pressure and temperature. It will not create a Flow Sensor, classic temperature, and Pressure sensor as these are not available.

https://phyn.com/products/phyn